### PR TITLE
Synchronise les dates last_value_still_valid_on depuis baremes-ipp-yaml

### DIFF
--- a/openfisca_france_pension/parameters/marche_travail/indemnite_fin_contrat/taux.yaml
+++ b/openfisca_france_pension/parameters/marche_travail/indemnite_fin_contrat/taux.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.1
 metadata:
   unit: /1
-  last_value_still_valid_on: "2024-03-14"
+  last_value_still_valid_on: "2025-03-28"
   reference:
     1990-01-01:
       title: Article L1243-8 du Code du travail

--- a/openfisca_france_pension/parameters/marche_travail/primes_exceptionnelles/prime_partage_valeur/plafond_exoneration.yaml
+++ b/openfisca_france_pension/parameters/marche_travail/primes_exceptionnelles/prime_partage_valeur/plafond_exoneration.yaml
@@ -4,7 +4,7 @@ values:
     value: 3000
 metadata:
   short_label: Premier plafond d'exonération
-  last_value_still_valid_on: "2024-03-13"
+  last_value_still_valid_on: "2025-03-28"
   unit: currency
   reference:
     2022-07-01:

--- a/openfisca_france_pension/parameters/marche_travail/primes_exceptionnelles/prime_partage_valeur/plafond_exoneration_avec_accord_interessement.yaml
+++ b/openfisca_france_pension/parameters/marche_travail/primes_exceptionnelles/prime_partage_valeur/plafond_exoneration_avec_accord_interessement.yaml
@@ -4,7 +4,7 @@ values:
     value: 6000
 metadata:
   short_label: Deuxième plafond d'exonération sous condition employeur
-  last_value_still_valid_on: "2024-03-13"
+  last_value_still_valid_on: "2025-03-25"
   unit: currency
   reference:
     2022-07-01:

--- a/openfisca_france_pension/parameters/marche_travail/primes_exceptionnelles/prime_partage_valeur/plafond_salaire.yaml
+++ b/openfisca_france_pension/parameters/marche_travail/primes_exceptionnelles/prime_partage_valeur/plafond_salaire.yaml
@@ -3,6 +3,7 @@ values:
   2022-07-01:
     value: 3
 metadata:
+  last_value_still_valid_on: "2025-03-25"
   short_label: Salaire maximal d'éligibilité à la PPV, en nombre de Smic annuels
   unit: smic_annuel
   reference:

--- a/openfisca_france_pension/parameters/marche_travail/salaire_minimum/minstage/taux_gratification_min.yaml
+++ b/openfisca_france_pension/parameters/marche_travail/salaire_minimum/minstage/taux_gratification_min.yaml
@@ -8,7 +8,7 @@ values:
     value: 0.15
 metadata:
   short_label: Part du PSS
-  last_value_still_valid_on: "2024-03-14"
+  last_value_still_valid_on: "2026-03-27"
   label_en: Minimum compensation for interns
   unit: /1
   reference:

--- a/openfisca_france_pension/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/apprentissage/csa/multiplicateur_alsace_moselle.yaml
+++ b/openfisca_france_pension/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/apprentissage/csa/multiplicateur_alsace_moselle.yaml
@@ -3,7 +3,7 @@ values:
   2012-01-01:
     value: 0.52
 metadata:
-  last_value_still_valid_on: "2024-05-16"
+  last_value_still_valid_on: "2026-03-27"
   unit: /1
   reference:
     2012-01-01:

--- a/openfisca_france_pension/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/apprentissage/csa/plus_de_2000_moins_de_1pc.yaml
+++ b/openfisca_france_pension/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/apprentissage/csa/plus_de_2000_moins_de_1pc.yaml
@@ -9,7 +9,7 @@ values:
   2014-01-01:
     value: 0.006
 metadata:
-  last_value_still_valid_on: "2024-05-16"
+  last_value_still_valid_on: "2026-03-27"
   unit: /1
   reference:
     2011-01-01:

--- a/openfisca_france_pension/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/apprentissage/csa/plus_de_250_entre_1_et_2pc.yaml
+++ b/openfisca_france_pension/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/apprentissage/csa/plus_de_250_entre_1_et_2pc.yaml
@@ -9,7 +9,7 @@ values:
   2015-01-01:
     value: 0.002
 metadata:
-  last_value_still_valid_on: "2024-05-16"
+  last_value_still_valid_on: "2026-03-27"
   ipp_csv_id: apprencsa_p_0_
   unit: /1
   reference:

--- a/openfisca_france_pension/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/apprentissage/csa/plus_de_250_entre_3_et_4pc.yaml
+++ b/openfisca_france_pension/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/apprentissage/csa/plus_de_250_entre_3_et_4pc.yaml
@@ -5,7 +5,7 @@ values:
   2015-01-01:
     value: 0.0005
 metadata:
-  last_value_still_valid_on: "2024-05-16"
+  last_value_still_valid_on: "2026-03-27"
   unit: /1
   reference:
     2011-01-01:

--- a/openfisca_france_pension/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/apprentissage/csa/plus_de_250_entre_4_et_5pc.yaml
+++ b/openfisca_france_pension/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/apprentissage/csa/plus_de_250_entre_4_et_5pc.yaml
@@ -3,7 +3,7 @@ values:
   2015-01-01:
     value: 0.0005
 metadata:
-  last_value_still_valid_on: "2024-05-16"
+  last_value_still_valid_on: "2026-03-27"
   unit: /1
   reference:
     2015-01-01:

--- a/openfisca_france_pension/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/apprentissage/csa/plus_de_250_moins_de_1pc.yaml
+++ b/openfisca_france_pension/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/apprentissage/csa/plus_de_250_moins_de_1pc.yaml
@@ -11,7 +11,7 @@ values:
   2014-01-01:
     value: 0.004
 metadata:
-  last_value_still_valid_on: "2024-05-16"
+  last_value_still_valid_on: "2026-03-27"
   unit: /1
   reference:
     2009-01-01:

--- a/openfisca_france_pension/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/contribution_unique_formation/contrib_formation_pro/moins_11_salaries.yaml
+++ b/openfisca_france_pension/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/contribution_unique_formation/contrib_formation_pro/moins_11_salaries.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.0055
 metadata:
   short_label: Employeur de moins de 11 salariés
-  last_value_still_valid_on: "2024-03-14"
+  last_value_still_valid_on: "2026-03-27"
   label_en: Unique employer's participation to lifelong professional training and apprenticeship
   unit: /1
   reference:

--- a/openfisca_france_pension/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/contribution_unique_formation/contrib_formation_pro/onze_et_plus_salaries.yaml
+++ b/openfisca_france_pension/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/contribution_unique_formation/contrib_formation_pro/onze_et_plus_salaries.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.01
 metadata:
   short_label: Employeur de 11 salariés et plus
-  last_value_still_valid_on: "2023-01-30"
+  last_value_still_valid_on: "2026-03-27"
   label_en: Unique employer's participation to lifelong professional training and apprenticeship
   unit: /1
   reference:

--- a/openfisca_france_pension/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/fnal/contribution_plus_de_50_salaries.yaml
+++ b/openfisca_france_pension/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/fnal/contribution_plus_de_50_salaries.yaml
@@ -8,7 +8,7 @@ brackets:
       value: 0.005
 metadata:
   short_label: Entreprises de plus de 50 salariés
-  last_value_still_valid_on: "2024-03-14"
+  last_value_still_valid_on: "2026-03-27"
   ipp_csv_id: fnal_p_p50_0_
   reference:
     2020-01-01:

--- a/openfisca_france_pension/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/prevoyance/prevoyance_obligatoire.yaml
+++ b/openfisca_france_pension/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/prevoyance/prevoyance_obligatoire.yaml
@@ -5,6 +5,7 @@ values:
   2019-01-01:
     value: 0.015
 metadata:
+  last_value_still_valid_on: "2025-11-17"
   short_label: Taux minimum
   label_en: Minimum rate of employer contribution for invalidity insurance for cadres
   unit: /1

--- a/openfisca_france_pension/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/cont_sur_options/salarie/taux_plein.yaml
+++ b/openfisca_france_pension/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/cont_sur_options/salarie/taux_plein.yaml
@@ -7,6 +7,7 @@ values:
   2012-07-11:
     value: 0.1
 metadata:
+  last_value_still_valid_on: "2026-03-27"
   short_label: Taux plein
   label_en: Contribution levied on options and shares granted for free
   ipp_csv_id: cont_opt_s_tx1

--- a/openfisca_france_pension/parameters/prelevements_sociaux/contributions_sociales/csg/activite/deductible/abattement.yaml
+++ b/openfisca_france_pension/parameters/prelevements_sociaux/contributions_sociales/csg/activite/deductible/abattement.yaml
@@ -22,7 +22,7 @@ brackets:
       value: 0
 metadata:
   short_label: Abattement
-  last_value_still_valid_on: "2024-03-13"
+  last_value_still_valid_on: "2025-01-22"
   label_en: CSG - rates on work incomes
   ipp_csv_id: csg_abt
   reference:

--- a/openfisca_france_pension/parameters/prelevements_sociaux/contributions_sociales/csg/activite/deductible/taux.yaml
+++ b/openfisca_france_pension/parameters/prelevements_sociaux/contributions_sociales/csg/activite/deductible/taux.yaml
@@ -8,7 +8,7 @@ values:
     value: 0.068
 metadata:
   short_label: Taux
-  last_value_still_valid_on: "2024-07-22"
+  last_value_still_valid_on: "2025-01-20"
   label_en: CSG - rates on work incomes
   ipp_csv_id: csg_act_ded
   unit: /1

--- a/openfisca_france_pension/parameters/prelevements_sociaux/contributions_sociales/csg/activite/taux_global.yaml
+++ b/openfisca_france_pension/parameters/prelevements_sociaux/contributions_sociales/csg/activite/taux_global.yaml
@@ -12,7 +12,7 @@ values:
     value: 0.092
 metadata:
   short_label: Taux global
-  last_value_still_valid_on: "2024-07-22"
+  last_value_still_valid_on: "2025-01-20"
   label_en: CSG - rates on work incomes
   ipp_csv_id: csg_act
   unit: /1

--- a/openfisca_france_pension/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_chomage/deductible/taux_plein.yaml
+++ b/openfisca_france_pension/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_chomage/deductible/taux_plein.yaml
@@ -8,7 +8,7 @@ values:
     value: 0.038
 metadata:
   short_label: Taux plein
-  last_value_still_valid_on: "2024-07-24"
+  last_value_still_valid_on: "2026-03-27"
   label_en: CSG - rates on unemployment incomes
   ipp_csv_id: csg_cho_ded
   unit: /1

--- a/openfisca_france_pension/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_chomage/deductible/taux_reduit.yaml
+++ b/openfisca_france_pension/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_chomage/deductible/taux_reduit.yaml
@@ -8,7 +8,7 @@ values:
     value: 0.038
 metadata:
   short_label: Taux réduit
-  last_value_still_valid_on: "2024-07-24"
+  last_value_still_valid_on: "2026-03-27"
   label_en: CSG - rates on unemployment incomes
   ipp_csv_id: csg_cho_red
   unit: /1

--- a/openfisca_france_pension/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_chomage/imposable/taux_plein.yaml
+++ b/openfisca_france_pension/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_chomage/imposable/taux_plein.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.024
 metadata:
   short_label: Taux plein
-  last_value_still_valid_on: "2024-07-24"
+  last_value_still_valid_on: "2026-03-27"
   label_en: CSG - rates on unemployment incomes
   unit: /1
   reference:

--- a/openfisca_france_pension/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_chomage/imposable/taux_reduit.yaml
+++ b/openfisca_france_pension/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_chomage/imposable/taux_reduit.yaml
@@ -4,7 +4,7 @@ values:
     value: 0
 metadata:
   short_label: Taux réduit
-  last_value_still_valid_on: "2024-07-24"
+  last_value_still_valid_on: "2026-03-27"
   label_en: CSG - rates on work incomes
   unit: /1
   reference:

--- a/openfisca_france_pension/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_chomage/min_exo.yaml
+++ b/openfisca_france_pension/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_chomage/min_exo.yaml
@@ -4,7 +4,7 @@ values:
     value: 1
 metadata:
   short_label: Montant imposable d'allocations chômage maximal exonéré
-  last_value_still_valid_on: "2002-01-01"
+  last_value_still_valid_on: "2024-07-24"
   unit: smic
   reference:
     2002-01-01:

--- a/openfisca_france_pension/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/indemnites_journalieres/deductible/taux.yaml
+++ b/openfisca_france_pension/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/indemnites_journalieres/deductible/taux.yaml
@@ -8,7 +8,7 @@ values:
     value: 0.038
 metadata:
   short_label: Taux
-  last_value_still_valid_on: "1998-01-01"
+  last_value_still_valid_on: "2025-02-21"
   ipp_csv_id: csg_ij_ded
   unit: /1
   reference:

--- a/openfisca_france_pension/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/indemnites_journalieres/taux_global.yaml
+++ b/openfisca_france_pension/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/indemnites_journalieres/taux_global.yaml
@@ -8,7 +8,7 @@ values:
     value: 0.062
 metadata:
   short_label: Taux global
-  last_value_still_valid_on: "1998-01-01"
+  last_value_still_valid_on: "2025-02-21"
   ipp_csv_id: csg_ij
   unit: /1
   reference:

--- a/openfisca_france_pension/parameters/prelevements_sociaux/cotisations_secteur_public/retraite/ati/ati.yaml
+++ b/openfisca_france_pension/parameters/prelevements_sociaux/cotisations_secteur_public/retraite/ati/ati.yaml
@@ -18,7 +18,7 @@ brackets:
       value: 0.0032
 metadata:
   short_label: Allocations temporaires d'invalidité (ATI)
-  last_value_still_valid_on: "2021-08-24"
+  last_value_still_valid_on: "2025-04-01"
   label_en: Contributions for pensions - central government (employer contribution)
   ipp_csv_id: txexp_ati_p
   reference:

--- a/openfisca_france_pension/parameters/prelevements_sociaux/cotisations_secteur_public/retraite/pension/employeur/militaires/pension.yaml
+++ b/openfisca_france_pension/parameters/prelevements_sociaux/cotisations_secteur_public/retraite/pension/employeur/militaires/pension.yaml
@@ -24,7 +24,7 @@ brackets:
       value: 1.2607
 metadata:
   short_label: Barème
-  last_value_still_valid_on: "2021-08-24"
+  last_value_still_valid_on: "2025-08-22"
   label_en: Contributions for pensions - central government (employer contribution)
   ipp_csv_id: txexp_mil_p
   reference:

--- a/openfisca_france_pension/parameters/prelevements_sociaux/cotisations_secteur_public/retraite/pension/salarie/pension.yaml
+++ b/openfisca_france_pension/parameters/prelevements_sociaux/cotisations_secteur_public/retraite/pension/salarie/pension.yaml
@@ -40,7 +40,7 @@ brackets:
       value: 0.111
 metadata:
   short_label: Pension
-  last_value_still_valid_on: "2021-08-24"
+  last_value_still_valid_on: "2025-08-22"
   label_en: Contributions for pensions - central government (employee contribution)
   ipp_csv_id: retpens_pu_s
   reference:

--- a/openfisca_france_pension/parameters/prelevements_sociaux/cotisations_securite_sociale_regime_general/casa/pensions_retraite_preretraite_invalidite.yaml
+++ b/openfisca_france_pension/parameters/prelevements_sociaux/cotisations_securite_sociale_regime_general/casa/pensions_retraite_preretraite_invalidite.yaml
@@ -8,7 +8,7 @@ brackets:
       value: 0.003
 metadata:
   short_label: Taux CASA
-  last_value_still_valid_on: "2021-12-07"
+  last_value_still_valid_on: "2025-03-28"
   label_en: "Additional SSC for autonomy (CASA: Additional solidarity Contribution for Autonomy)"
   ipp_csv_id: casa_pens
   reference:

--- a/openfisca_france_pension/parameters/prelevements_sociaux/cotisations_taxes_independants_artisans_commercants/ret_comp_ac/art_ind_com/entre_1_plafond_rci_et_4_plafonds_pss.yaml
+++ b/openfisca_france_pension/parameters/prelevements_sociaux/cotisations_taxes_independants_artisans_commercants/ret_comp_ac/art_ind_com/entre_1_plafond_rci_et_4_plafonds_pss.yaml
@@ -3,6 +3,7 @@ values:
   2013-01-01:
     value: 0.08
 metadata:
+  last_value_still_valid_on: "2025-08-20"
   short_label: Taux entre 1 plafond RCI et 4 plafonds PSS
   label_en: Contribution for complementary pension scheme (sales retailers and craftsmen)
   ipp_csv_id: retc_rci_1_4plaf

--- a/openfisca_france_pension/parameters/prelevements_sociaux/professions_liberales/formation_pl/sous_pss.yaml
+++ b/openfisca_france_pension/parameters/prelevements_sociaux/professions_liberales/formation_pl/sous_pss.yaml
@@ -6,7 +6,7 @@ values:
     value: 0.0025
 metadata:
   short_label: Taux (sous PSS)
-  last_value_still_valid_on: "2022-04-06"
+  last_value_still_valid_on: "2025-02-21"
   label_en: Contribution to lifelong professional training (professionals)
   ipp_csv_id: form_plib_0_1
   unit: /1

--- a/openfisca_france_pension/parameters/prelevements_sociaux/reductions_cotisations_sociales/agricole/tode/plafond.yaml
+++ b/openfisca_france_pension/parameters/prelevements_sociaux/reductions_cotisations_sociales/agricole/tode/plafond.yaml
@@ -4,7 +4,7 @@ values:
     value: 1.6
 metadata:
   short_label: Point d'annulation TO-DE
-  last_value_still_valid_on: "2022-09-21"
+  last_value_still_valid_on: "2025-02-21"
   label_en: Ceiling of resources in SSCs exemption for casual worker job seeker (TO-DE, agricultural worker)
   unit: smic
   reference:

--- a/openfisca_france_pension/parameters/prelevements_sociaux/reductions_cotisations_sociales/alleg_gen/dispositifs_de_reductions_des_cotisations_famille_1993_1996/1_1_1_2_smic.yaml
+++ b/openfisca_france_pension/parameters/prelevements_sociaux/reductions_cotisations_sociales/alleg_gen/dispositifs_de_reductions_des_cotisations_famille_1993_1996/1_1_1_2_smic.yaml
@@ -8,7 +8,7 @@ values:
     value: null
 metadata:
   short_label: De 1,1 à 1,2 Smic
-  last_value_still_valid_on: "1996-10-01"
+  last_value_still_valid_on: "2025-01-17"
   label_en: Global reduction in SSCs
   ipp_csv_id: tx_csp_exo_fam_1_2
   unit: /1

--- a/openfisca_france_pension/parameters/prelevements_sociaux/regimes_complementaires_retraite_secteur_prive/agirc_arrco/employeur/agirc_arrco.yaml
+++ b/openfisca_france_pension/parameters/prelevements_sociaux/regimes_complementaires_retraite_secteur_prive/agirc_arrco/employeur/agirc_arrco.yaml
@@ -20,7 +20,7 @@ brackets:
       value: 0
 metadata:
   short_label: Barème employeur
-  last_value_still_valid_on: "2021-08-02"
+  last_value_still_valid_on: "2025-08-20"
   label_en: Complementary pension contributions
   reference:
     2019-01-01:

--- a/openfisca_france_pension/parameters/prelevements_sociaux/regimes_complementaires_retraite_secteur_prive/agirc_arrco/tx_calcul.yaml
+++ b/openfisca_france_pension/parameters/prelevements_sociaux/regimes_complementaires_retraite_secteur_prive/agirc_arrco/tx_calcul.yaml
@@ -20,7 +20,7 @@ brackets:
       value: 0
 metadata:
   short_label: Taux de calcul de points
-  last_value_still_valid_on: "2021-08-02"
+  last_value_still_valid_on: "2025-08-20"
   label_en: Complementary pension contributions
   reference:
     2019-01-01:

--- a/openfisca_france_pension/parameters/prelevements_sociaux/regimes_complementaires_retraite_secteur_prive/agirc_arrco/tx_total.yaml
+++ b/openfisca_france_pension/parameters/prelevements_sociaux/regimes_complementaires_retraite_secteur_prive/agirc_arrco/tx_total.yaml
@@ -20,7 +20,7 @@ brackets:
       value: 0
 metadata:
   short_label: Barème total
-  last_value_still_valid_on: "2021-08-02"
+  last_value_still_valid_on: "2025-08-20"
   label_en: Complementary pension contributions
   reference:
     2019-01-01:

--- a/openfisca_france_pension/parameters/prelevements_sociaux/regimes_complementaires_retraite_secteur_prive/cet2019/employeur/cet2019.yaml
+++ b/openfisca_france_pension/parameters/prelevements_sociaux/regimes_complementaires_retraite_secteur_prive/cet2019/employeur/cet2019.yaml
@@ -14,7 +14,7 @@ brackets:
       value: 0
 metadata:
   short_label: Barème
-  last_value_still_valid_on: "2021-07-30"
+  last_value_still_valid_on: "2025-08-20"
   label_en: Complementary pension contributions
   reference:
     2019-01-01:

--- a/openfisca_france_pension/parameters/prelevements_sociaux/regimes_complementaires_retraite_secteur_prive/cet2019/salarie/cet2019.yaml
+++ b/openfisca_france_pension/parameters/prelevements_sociaux/regimes_complementaires_retraite_secteur_prive/cet2019/salarie/cet2019.yaml
@@ -14,7 +14,7 @@ brackets:
       value: 0
 metadata:
   short_label: Barème
-  last_value_still_valid_on: "2021-07-30"
+  last_value_still_valid_on: "2025-08-20"
   label_en: Complementary pension contributions
   reference:
     2019-01-01:

--- a/openfisca_france_pension/parameters/retraites/secteur_public/regimes_complementaires/ircantec/coefficient_de_minoration/decote_maximale.yaml
+++ b/openfisca_france_pension/parameters/retraites/secteur_public/regimes_complementaires/ircantec/coefficient_de_minoration/decote_maximale.yaml
@@ -1,5 +1,6 @@
 description: Taux de décote maximal
 metadata:
+  last_value_still_valid_on: "2025-01-24"
   reference:
     1971-01-01:
       href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000006381606/1971-02-09/#LEGIARTI000006381606


### PR DESCRIPTION
## Résumé

Cette PR met à jour 40 champs `metadata.last_value_still_valid_on` depuis `baremes-ipp-yaml`.

Elle ne modifie pas les valeurs de calcul.

## Contexte

Cette PR sert de test pratique pour la synchronisation progressive discutée ici :

- https://github.com/openfisca/openfisca-france-pension/issues/19
- https://gitlab.com/ipp/partage-public-ipp/baremes-ipp/baremes-ipp-yaml/-/work_items/230

Le diagnostic affiné montrait que ces 40 fichiers avaient une date `last_value_still_valid_on` plus récente côté `baremes-ipp-yaml`, et que c'était la seule différence après exclusion de ce champ.

## Vérification effectuée

Un script local a vérifié que, pour les 40 fichiers modifiés :

- seul `metadata.last_value_still_valid_on` change ;
- la date est ajoutée ou augmentée ;
- le contenu de calcul reste identique.

Résultat :

```text
Changed files: 40
Verification OK: only metadata.last_value_still_valid_on was added or increased
```
