### PR TITLE
Met à jour la stack GitHub Actions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: ["ubuntu-24.04"]  # On peut ajouter "macos-latest" si besoin
-        python-version: ["3.10.11"]
+        os: ["ubuntu-22.04"]  # On peut ajouter "macos-latest" si besoin
+        python-version: ["3.9"]
         openfisca-dependencies: [minimal, maximal]
     steps:
       - name: Checkout
@@ -44,7 +44,7 @@ jobs:
           key: release-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-${{ matrix.os }}-${{ matrix.openfisca-dependencies }}
 
   lint-files:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         dependencies-version: [maximal]
@@ -56,13 +56,13 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.10.11
+          python-version: 3.9
       - name: Cache build
         id: restore-build
         uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
-          key: build-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-ubuntu-24.04-${{ matrix.dependencies-version }}
+          key: build-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-ubuntu-22.04-${{ matrix.dependencies-version }}
       - run: make check-syntax-errors
       - run: make check-style
       - name: Lint Python files
@@ -75,8 +75,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ "ubuntu-24.04" ]  # On peut ajouter "macos-latest" si besoin
-        python-version: ["3.10.11"]
+        os: [ "ubuntu-22.04" ]  # On peut ajouter "macos-latest" si besoin
+        python-version: ["3.9"]
         openfisca-dependencies: [minimal, maximal]
     steps:
       - uses: actions/checkout@v4
@@ -93,21 +93,21 @@ jobs:
       - run: |
           shopt -s globstar
           openfisca test tests/**/*.py
-        if: matrix.openfisca-dependencies != 'minimal' || matrix.python-version != '3.10.11'
+        if: matrix.openfisca-dependencies != 'minimal' || matrix.python-version != '3.9'
 
   test-path-length:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.10.11
+          python-version: 3.9
       # - name: Test max path length
       #   run: make check-path-length
 
   test-yaml:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     needs: [ build ]
     strategy:
       fail-fast: false
@@ -123,13 +123,13 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.10.11
+          python-version: 3.9
       - name: Cache build
         id: restore-build
         uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
-          key: build-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-ubuntu-24.04-${{ matrix.openfisca-dependencies }}
+          key: build-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-ubuntu-22.04-${{ matrix.openfisca-dependencies }}
       - name: Split YAML tests
         id: yaml-test
         env:
@@ -142,7 +142,7 @@ jobs:
           openfisca test ${TEST_FILES_SUBLIST}
 
   test-api:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         dependencies-version: [maximal]
@@ -152,18 +152,18 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.10.11
+          python-version: 3.9
       - name: Cache build
         id: restore-build
         uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
-          key: build-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-ubuntu-24.04-${{ matrix.dependencies-version }}
+          key: build-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-ubuntu-22.04-${{ matrix.dependencies-version }}
       # - name: Test the Web API
       #   run: "${GITHUB_WORKSPACE}/.github/test-api.sh"
 
   check-version-and-changelog:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     needs: [ lint-files, test-python, test-yaml, test-api ] # Last job to run
     steps:
       - uses: actions/checkout@v4
@@ -172,7 +172,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.10.11
+          python-version: 3.9
       - name: Check version number has been properly updated
         run: "${GITHUB_WORKSPACE}/.github/is-version-number-acceptable.sh"
 
@@ -180,7 +180,7 @@ jobs:
   # We build a separate job to substitute the halt option.
   # The `deploy` job is dependent on the output of the `check-for-functional-changes` job.
   check-for-functional-changes:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     if: github.ref == 'refs/heads/master' # Only triggered for the `master` branch
     needs: [ check-version-and-changelog ]
     outputs:
@@ -192,12 +192,12 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.10.11
+          python-version: 3.9
       - id: stop-early
         run: if "${GITHUB_WORKSPACE}/.github/has-functional-changes.sh" ; then echo "status=success" >> "$GITHUB_OUTPUT" ; fi
 
   deploy:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         dependencies-version: [maximal]
@@ -213,19 +213,19 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.10.11
+          python-version: 3.9
       - name: Cache build
         id: restore-build
         uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
-          key: build-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-ubuntu-24.04-${{ matrix.dependencies-version }}
+          key: build-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-ubuntu-22.04-${{ matrix.dependencies-version }}
       - name: Cache release
         id: restore-release
         uses: actions/cache@v4
         with:
           path: dist
-          key: release-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-ubuntu-24.04-${{ matrix.dependencies-version }}
+          key: release-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-ubuntu-22.04-${{ matrix.dependencies-version }}
       - name: Upload a Python package to PyPi
         run: twine upload dist/* --username $PYPI_USERNAME --password $PYPI_TOKEN
       - name: Publish a git tag

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -3,7 +3,7 @@ name: OpenFisca France Pension
 on:
   push:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
 
 jobs:
   build:
@@ -11,19 +11,19 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: ["ubuntu-20.04"]  # On peut ajouter "macos-latest" si besoin
+        os: ["ubuntu-24.04"]  # On peut ajouter "macos-latest" si besoin
         python-version: ["3.9.9"]
         openfisca-dependencies: [minimal, maximal]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Cache build
         id: restore-build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
           key: build-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-${{ matrix.os }}-${{ matrix.openfisca-dependencies }}
@@ -38,31 +38,31 @@ jobs:
             pip install $(python ${GITHUB_WORKSPACE}/.github/get_minimal_version.py)
       - name: Cache release
         id: restore-release
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: dist
           key: release-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-${{ matrix.os }}-${{ matrix.openfisca-dependencies }}
 
   lint-files:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         dependencies-version: [maximal]
     needs: [ build ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch all the tags
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9.9
       - name: Cache build
         id: restore-build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
-          key: build-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-ubuntu-20.04-${{ matrix.dependencies-version }}
+          key: build-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-ubuntu-24.04-${{ matrix.dependencies-version }}
       - run: make check-syntax-errors
       - run: make check-style
       - name: Lint Python files
@@ -75,18 +75,18 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ "ubuntu-20.04" ]  # On peut ajouter "macos-latest" si besoin
+        os: [ "ubuntu-24.04" ]  # On peut ajouter "macos-latest" si besoin
         python-version: ["3.9.9"]
         openfisca-dependencies: [minimal, maximal]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Cache build
         id: restore-build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
           key: build-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-${{ matrix.os }}-${{ matrix.openfisca-dependencies }}
@@ -96,18 +96,18 @@ jobs:
         if: matrix.openfisca-dependencies != 'minimal' || matrix.python-version != '3.9.9'
 
   test-path-length:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9.9
       # - name: Test max path length
       #   run: make check-path-length
 
   test-yaml:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [ build ]
     strategy:
       fail-fast: false
@@ -119,17 +119,17 @@ jobs:
         openfisca-dependencies: [minimal, maximal]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9.9
       - name: Cache build
         id: restore-build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
-          key: build-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-ubuntu-20.04-${{ matrix.openfisca-dependencies }}
+          key: build-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-ubuntu-24.04-${{ matrix.openfisca-dependencies }}
       - name: Split YAML tests
         id: yaml-test
         env:
@@ -142,35 +142,35 @@ jobs:
           openfisca test ${TEST_FILES_SUBLIST}
 
   test-api:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         dependencies-version: [maximal]
     needs: [ build ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9.9
       - name: Cache build
         id: restore-build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
-          key: build-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-ubuntu-20.04-${{ matrix.dependencies-version }}
+          key: build-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-ubuntu-24.04-${{ matrix.dependencies-version }}
       # - name: Test the Web API
       #   run: "${GITHUB_WORKSPACE}/.github/test-api.sh"
 
   check-version-and-changelog:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [ lint-files, test-python, test-yaml, test-api ] # Last job to run
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch all the tags
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9.9
       - name: Check version number has been properly updated
@@ -180,24 +180,24 @@ jobs:
   # We build a separate job to substitute the halt option.
   # The `deploy` job is dependent on the output of the `check-for-functional-changes` job.
   check-for-functional-changes:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: github.ref == 'refs/heads/master' # Only triggered for the `master` branch
     needs: [ check-version-and-changelog ]
     outputs:
       status: ${{ steps.stop-early.outputs.status }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch all the tags
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9.9
       - id: stop-early
-        run: if "${GITHUB_WORKSPACE}/.github/has-functional-changes.sh" ; then echo "::set-output name=status::success" ; fi
+        run: if "${GITHUB_WORKSPACE}/.github/has-functional-changes.sh" ; then echo "status=success" >> "$GITHUB_OUTPUT" ; fi
 
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         dependencies-version: [maximal]
@@ -207,25 +207,25 @@ jobs:
       PYPI_USERNAME: __token__
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch all the tags
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9.9
       - name: Cache build
         id: restore-build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
-          key: build-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-ubuntu-20.04-${{ matrix.dependencies-version }}
+          key: build-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-ubuntu-24.04-${{ matrix.dependencies-version }}
       - name: Cache release
         id: restore-release
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: dist
-          key: release-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-ubuntu-20.04-${{ matrix.dependencies-version }}
+          key: release-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-ubuntu-24.04-${{ matrix.dependencies-version }}
       - name: Upload a Python package to PyPi
         run: twine upload dist/* --username $PYPI_USERNAME --password $PYPI_TOKEN
       - name: Publish a git tag

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-24.04"]  # On peut ajouter "macos-latest" si besoin
-        python-version: ["3.9.9"]
+        python-version: ["3.10.11"]
         openfisca-dependencies: [minimal, maximal]
     steps:
       - name: Checkout
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9.9
+          python-version: 3.10.11
       - name: Cache build
         id: restore-build
         uses: actions/cache@v4
@@ -76,7 +76,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ "ubuntu-24.04" ]  # On peut ajouter "macos-latest" si besoin
-        python-version: ["3.9.9"]
+        python-version: ["3.10.11"]
         openfisca-dependencies: [minimal, maximal]
     steps:
       - uses: actions/checkout@v4
@@ -93,7 +93,7 @@ jobs:
       - run: |
           shopt -s globstar
           openfisca test tests/**/*.py
-        if: matrix.openfisca-dependencies != 'minimal' || matrix.python-version != '3.9.9'
+        if: matrix.openfisca-dependencies != 'minimal' || matrix.python-version != '3.10.11'
 
   test-path-length:
     runs-on: ubuntu-24.04
@@ -102,7 +102,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9.9
+          python-version: 3.10.11
       # - name: Test max path length
       #   run: make check-path-length
 
@@ -123,7 +123,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9.9
+          python-version: 3.10.11
       - name: Cache build
         id: restore-build
         uses: actions/cache@v4
@@ -152,7 +152,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9.9
+          python-version: 3.10.11
       - name: Cache build
         id: restore-build
         uses: actions/cache@v4
@@ -172,7 +172,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9.9
+          python-version: 3.10.11
       - name: Check version number has been properly updated
         run: "${GITHUB_WORKSPACE}/.github/is-version-number-acceptable.sh"
 
@@ -192,7 +192,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9.9
+          python-version: 3.10.11
       - id: stop-early
         run: if "${GITHUB_WORKSPACE}/.github/has-functional-changes.sh" ; then echo "status=success" >> "$GITHUB_OUTPUT" ; fi
 
@@ -213,7 +213,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9.9
+          python-version: 3.10.11
       - name: Cache build
         id: restore-build
         uses: actions/cache@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 0.1.3 [21](https://github.com/openfisca/openfisca-france-pension/pull/21)
+
+* Amélioration technique.
+* Détails :
+  - Met à jour la stack GitHub Actions pour débloquer la CI.
+  - Resserre temporairement la compatibilité OpenFisca-Core à `<43`.
+
 ### 0.1.2 [15](https://https://github.com/openfisca/openfisca-france-pension/pull/15)
 
 * Mise à jour dépendance OpenFisca-Core afin de résoudre conflit de dépendances avec OpenFisca-Survey-Manager

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         ],
     install_requires = [
         "bottleneck >=1.3.2,<=2.0.0",
-        "OpenFisca-Core >= 41.5.0,<43.5",
+        "OpenFisca-Core >= 41.5.0,<43",
         "numba>=0.54,<1.0.0",
         "pandas>=2.0,<3.0",
         ],

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         ],
     install_requires = [
         "bottleneck >=1.3.2,<=2.0.0",
-        "OpenFisca-Core >= 41.5.0,<44",
+        "OpenFisca-Core >= 41.5.0,<43.5",
         "numba>=0.54,<1.0.0",
         "pandas>=2.0,<3.0",
         ],

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 setup(
     name = "OpenFisca-France-Pension",
     python_requires='>=3.9',
-    version = "0.1.2",
+    version = "0.1.3",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.org",
     classifiers=[


### PR DESCRIPTION
## Résumé

Cette PR met à jour la stack GitHub Actions du workflow principal pour débloquer les runs restés en file d'attente.

## Changements

- passe les runners de `ubuntu-20.04` à `ubuntu-24.04` ;
- met à jour `actions/checkout` de `v3` vers `v4` ;
- met à jour `actions/setup-python` de `v4` vers `v5` ;
- met à jour `actions/cache` de `v3` vers `v4` ;
- ajoute `synchronize` aux événements `pull_request` ;
- remplace `::set-output` par `$GITHUB_OUTPUT`.

## Portée

La version Python testée reste `3.9.9` pour limiter le changement au strict nécessaire.

Cette PR est séparée de la PR de données #20, dont le workflow principal est actuellement bloqué en `queued` alors que `Validate YAML` passe.

## Point d'attention

Si des checks obligatoires sont configurés avec les anciens noms incluant `ubuntu-20.04`, il faudra peut-être ajuster la protection de branche après merge.
